### PR TITLE
Breadcrumb fix

### DIFF
--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -1,5 +1,6 @@
 <script>
     import logotype from "$lib/assets/logotype.png?run&lqip=0";
+    let props = $props();
 </script>
 <nav
     aria-label="Breadcrumb"
@@ -16,7 +17,7 @@
         <!-- TODO: calculate this dynamically -->
         <li class="inline-block p-2">
             <a href="#top" aria-current="page" class="font-semibold text-black"
-                >{document.title}</a
+                >{props.pageTitle}</a
             >
         </li>
     </ol>

--- a/src/routes/games/+page.svelte
+++ b/src/routes/games/+page.svelte
@@ -5,7 +5,7 @@
     import Img from "@zerodevx/svelte-img";
 </script>
 
-<Breadcrumbs />
+<Breadcrumbs pageTitle="Games"/>
 
 <main class="w-full p-9">
     <ol class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/routes/mods/+page.svelte
+++ b/src/routes/mods/+page.svelte
@@ -37,7 +37,7 @@
     mods.sort((a, b) => a.displayName.localeCompare(b.displayName));
 </script>
 
-<Breadcrumbs />
+<Breadcrumbs pageTitle="Mods"/>
 
 <div
     class="flex w-full max-w-xl grow flex-col items-center gap-16 self-center p-4"


### PR DESCRIPTION
If you load the pages with breadcrumbs fast enough, document doesn't exist for the breadcrumb to pull document.title, and so it throws a 500 error. This solution uses Svelte props to avoid that, because it passes in the page title to the component on load.